### PR TITLE
fix: prevent logged-in users from accessing login/signup pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 import SetupProtectedRoute from './components/SetupProtectedRoute';
 import RecurringTransactions from './pages/RecurringTransactions';
-import { PublicRoute } from './components/gaurds';
+import { PublicRoute } from './components/PublicRoute';
 
 function App() {
   return (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import Layout from './components/Layout';
 import ProtectedRoute from './components/ProtectedRoute';
 import SetupProtectedRoute from './components/SetupProtectedRoute';
 import RecurringTransactions from './pages/RecurringTransactions';
+import { PublicRoute } from './components/gaurds';
 
 function App() {
   return (
@@ -22,8 +23,8 @@ function App() {
       <Routes>
         {/* Public Routes */}
         <Route path="/" element={<WelcomePage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/register" element={<RegisterPage />} />
+        <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+        <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
         <Route path="/contact" element={<ContactUs />} />
         {/* Protected Routes */}
         <Route
@@ -42,7 +43,7 @@ function App() {
             </SetupProtectedRoute>
           }
         >
-          <Route path="/dashboard" element={<DashboardPage />} />
+          <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
           <Route path="/transactions" element={<TransactionsPage />} />
           <Route path="/receipts" element={<ReceiptsPage />} />
           <Route path="/settings" element={<SettingsPage />} />

--- a/frontend/src/components/PublicRoute.jsx
+++ b/frontend/src/components/PublicRoute.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuth from '../hooks/useAuth';
+import Spinner from './Spinner';
+
+const PublicRoute = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+};
+
+export default PublicRoute;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Implemented a `PublicRoute` component to prevent authenticated users from accessing the `/login` and `/signup` pages.  
- If a user is already logged in, they are automatically redirected to the `/dashboard`.

## Related Issue
<!--- If this PR addresses an existing issue, link it here -->
Fixes #106 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- This change improves user experience and route security by ensuring that logged-in users cannot manually navigate to authentication pages.  
- Previously, users could access `/login` even after logging in, which could cause confusion or session inconsistencies.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)

## How Has This Been Tested?
- Verified manually by logging in and attempting to navigate to `/login` and `/signup` pages.
- Confirmed redirect to `/dashboard` when authenticated.
- Tested behavior for logged-out users to ensure they can still access `/login` and `/signup`.

## Screenshots (if applicable):
<!--- Add screenshots or screen recordings if UI is affected -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

