### PR TITLE
fix(theme): set html.dark before first paint to match Tailwind dark s…

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -17,6 +17,8 @@ if (savedTheme) {
   initialTheme = 'dark';
 }
 updateFavicon(initialTheme);
+// Ensure the dark class is applied before first paint to avoid mismatch/flash
+document.documentElement.classList.toggle('dark', initialTheme === 'dark');
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
fix(theme): apply dark class before first paint for consistent dark mode
Toggle documentElement.dark in main.jsx based on saved/system preference
Prevents initial light render and FOUC with Tailwind darkMode:'class'
ThemeContext toggle behavior unchanged