### PR TITLE
FIX #125 minimum value for transactions amounts

### DIFF
--- a/frontend/src/components/TransactionModal.jsx
+++ b/frontend/src/components/TransactionModal.jsx
@@ -142,7 +142,7 @@ const TransactionModal = ({ isOpen, onClose, onSubmit, transaction, expenseCateg
 
               <div className="mb-4">
                 <label className="block text-gray-700">Amount (Expense)</label>
-                <input type="number" name="cost" value={formData.cost} onChange={handleChange} className="w-full px-3 py-2 border rounded" required />
+                <input type="number" name="cost" value={formData.cost} onChange={handleChange} className="w-full px-3 py-2 border rounded" required min="0" />
               </div>
 
               <div className="mb-4">
@@ -185,7 +185,7 @@ const TransactionModal = ({ isOpen, onClose, onSubmit, transaction, expenseCateg
 
               <div className="mb-4">
                 <label className="block text-gray-700">Amount (Income)</label>
-                <input type="number" name="cost" value={formData.cost} onChange={handleChange} className="w-full px-3 py-2 border rounded" required />
+                <input type="number" name="cost" value={formData.cost} onChange={handleChange} className="w-full px-3 py-2 border rounded" required min="0" />
               </div>
 
               <div className="mb-4">


### PR DESCRIPTION
Fixes #125 

Set minimum value for transaction amount to be 0, so it doesnt allow users to type negative amounts.
Modified in TransactionModal.jsx 

<img width="703" height="792" alt="Screenshot 2025-10-24 at 6 34 08 PM" src="https://github.com/user-attachments/assets/7c7939bf-5845-47f5-8ff5-e4da33a99a94" />

