### PR TITLE
Fix: Dark mode country flags invisible in currency selection (#166)

### DIFF
--- a/frontend/src/pages/SetupPage.jsx
+++ b/frontend/src/pages/SetupPage.jsx
@@ -66,7 +66,7 @@ const SetupPage = () => {
                     className="sr-only"
                   />
                   <div className="flex items-center space-x-3">
-                    <span className="text-2xl">{currency.flag}</span>
+                    <span className="text-2xl text-black dark:text-white">{currency.flag}</span>
                     <div>
                       <div className="font-medium text-gray-900 dark:text-white">
                         {currency.name}


### PR DESCRIPTION
## Description
This PR fixes the issue where country flags or associated text were not visible in dark mode on the currency selection screen. The solution applies Tailwind CSS classes (`text-black dark:text-white`) to the relevant div, ensuring proper text colour contrast in both light and dark modes.

## Related Issue
Fixes #166

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed