### PR TITLE
fix: Navbar overflow issue

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -37,7 +37,7 @@ const Layout = () => {
       Paisable
     </span>
 
-              <div className="hidden md:block">
+              <div className="hidden lg:block">
                 <div className="ml-10 flex items-baseline space-x-4">
                   <NavLink to="/dashboard" className={getNavLinkClass}>
                     Dashboard


### PR DESCRIPTION
## Description
- Fixed navbar overflow issue by tweaking CSS 

Fixes #122 

## Motivation and Context

- Navbar was breaking at the time of responsiveness , breaking the styling consistency of fully responsive page across all screen 

## Types of Changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [  x ] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)

## Screenshots (if applicable):
 
 - Before: 
 
<img width="1888" height="927" alt="image" src="https://github.com/user-attachments/assets/93998926-2887-4746-a944-ebe7c7e114ff" />

- After:

<img width="1919" height="924" alt="image" src="https://github.com/user-attachments/assets/50988448-63e5-49fb-a09b-3f92609c8209" />



