### PR TITLE
fix: add inline variant to Spinner to prevent button expansion

### DIFF
--- a/frontend/src/components/Spinner.jsx
+++ b/frontend/src/components/Spinner.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-const Spinner = () => {
+const Spinner = ({ inline = false }) => {
+  if (inline) {
+    return (
+      <div className="w-5 h-5 border-2 border-dashed rounded-full animate-spin border-white"></div>
+    );
+  }
+
   return (
     <div className="flex justify-center items-center py-10">
       <div className="w-16 h-16 border-4 border-dashed rounded-full animate-spin border-blue-600"></div>

--- a/frontend/src/pages/SetupPage.jsx
+++ b/frontend/src/pages/SetupPage.jsx
@@ -94,7 +94,7 @@ const SetupPage = () => {
           >
             {loading ? (
               <>
-                <Spinner />
+                <Spinner inline />
                 <span className="ml-2">Setting up...</span>
               </>
             ) : (


### PR DESCRIPTION
### Issue Resolved
Closes #173 

### Changes
- Added `inline` prop to Spinner component
- When `inline={true}`, renders a compact 5x5 spinner without padding wrapper
- Default behaviour (`inline={false}`) maintains original centred spinner with padding for full-page loading states
- Updated button loading state to use `<Spinner inline />` variant

### Why This Works
Buttons already have their own flex layout and padding. The original spinner's wrapper with `py-10` (40px vertical padding) conflicted with button dimensions. The inline variant removes this wrapper, allowing the spinner to fit naturally within button content.

### Testing
- Verified button maintains normal size with loading spinner
- Confirmed standalone spinner still works for full-page loading states

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improvement to an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Test (adds or updates tests only)
- [ ] Documentation (non-code change)


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

